### PR TITLE
Remove unused dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/backpack-exchange/bpx-api-client"
 [workspace.dependencies]
 anyhow = "1.0.93"
 base64 = "0.22.1"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { default-features = false, version = "0.4.38", features = ["serde"] }
 ed25519-dalek = "2.1.1"
-futures-util = "0.3.31"
+futures-util = { default-features = false, version = "0.3.31" }
 reqwest = { version = "0.12.5", default-features = false, features = [
   "json",
   "rustls-tls",


### PR DESCRIPTION
Some dependencies were bringing unnecessary transients and they were removed through the use of `default-features = false`. `cargo build` goes from 184 dependencies to 182 dependencies sightly reducing compilation times.