### PR TITLE
change visibility + type for MarginFunction

### DIFF
--- a/rust/types/src/margin.rs
+++ b/rust/types/src/margin.rs
@@ -1,10 +1,11 @@
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MarginFunction {
-    base: String,
-    factor: String,
+    pub base: Decimal,
+    pub factor: Decimal,
     #[serde(rename = "type")]
-    function_type: String,
+    pub function_type: String,
 }


### PR DESCRIPTION
Another PR for switching the visibility of `MarginFunction` fields.
I think it makes more sense to use Decimal here.