### PR TITLE
Add missing `auto_lend_redeem` param on withdrawal

### DIFF
--- a/rust/types/src/capital.rs
+++ b/rust/types/src/capital.rs
@@ -72,6 +72,8 @@ pub struct RequestWithdrawalPayload {
     pub two_factor_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_lend_redeem: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_borrow: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Another PR for a missing param on withdrawal :)