### PR TITLE
Reduce the size of the `Error` enum

### DIFF
--- a/rust/client/src/error.rs
+++ b/rust/client/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("Backpack API error: {status_code}: {message}")]
     BpxApiError {
         status_code: reqwest::StatusCode,
-        message: String,
+        message: Box<str>,
     },
 
     /// Invalid HTTP header value.
@@ -26,7 +26,7 @@ pub enum Error {
 
     /// Represents an invalid request with a custom message.
     #[error("Invalid request: {0}")]
-    InvalidRequest(String),
+    InvalidRequest(Box<str>),
 
     /// General HTTP client error from `reqwest`.
     #[error(transparent)]
@@ -50,5 +50,5 @@ pub enum Error {
 
     /// Invalid URL format.
     #[error("Invalid URL: {0}")]
-    UrlParseError(String),
+    UrlParseError(Box<str>),
 }

--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -175,7 +175,7 @@ impl BpxClient {
             let err_text = res.text().await?;
             let err = Error::BpxApiError {
                 status_code: e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-                message: err_text,
+                message: err_text.into(),
             };
             return Err(err);
         }
@@ -278,7 +278,7 @@ impl BpxClient {
                     .into_iter()
                     .map(|(k, v)| (k, v.to_string()))
                     .collect::<BTreeMap<_, _>>(),
-                _ => return Err(Error::InvalidRequest("payload must be a JSON object".to_string())),
+                _ => return Err(Error::InvalidRequest("payload must be a JSON object".into())),
             }
         } else {
             BTreeMap::new()

--- a/rust/client/src/routes/order.rs
+++ b/rust/client/src/routes/order.rs
@@ -17,8 +17,7 @@ impl BpxClient {
         } else {
             url.push_str(&format!(
                 "&clientId={}",
-                client_id
-                    .ok_or_else(|| Error::InvalidRequest("either order_id or client_id is required".to_string()))?
+                client_id.ok_or_else(|| Error::InvalidRequest("either order_id or client_id is required".into()))?
             ));
         }
         let res = self.get(url).await?;


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts 8 bytes from the `Error` enum through the use of `Box<str>` instead of `String`, which doesn't change any intended behavior.

Of course, 8 bytes won't make much of a runtime different in this project but it is still worthwhile IMO. 