### PR TITLE
Depend on versioned bpx-api-types; Bump to 0.6.3

### DIFF
--- a/rust/client/Cargo.toml
+++ b/rust/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpx-api-client"
-version = "0.6.2"
+version = "0.6.3"
 license = "Apache-2.0"
 edition = "2021"
 description = "Backpack Exchange API client"
@@ -8,7 +8,7 @@ repository = "https://github.com/backpack-exchange/bpx-api-client"
 
 [dependencies]
 base64 = { workspace = true }
-bpx-api-types = { path = "../types", version = "0.6.2" }
+bpx-api-types = { path = "../types", version = "0.6.3" }
 ed25519-dalek = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/rust/client/Cargo.toml
+++ b/rust/client/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/backpack-exchange/bpx-api-client"
 
 [dependencies]
 base64 = { workspace = true }
-bpx-api-types = { path = "../types" }
+bpx-api-types = { path = "../types", version = "0.6.2" }
 ed25519-dalek = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpx-api-types"
-version = "0.6.2"
+version = "0.6.3"
 license = "Apache-2.0"
 edition = "2021"
 description = "Backpack Exchange API types"


### PR DESCRIPTION
Path dependencies get ignored when a crate is published.

See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
```
error: all dependencies must have a version specified when publishing.
dependency `bpx-api-types` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```

Explicit versioning is required.
This is a necessary condition for publishing or updating a crate.

cc @tomlinton 