### PR TITLE
Add remaining RFQ fields and log websocket errors

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,5 +23,8 @@ serde_json = "1.0.125"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.63"
 tokio = { version = "1.41.1", features = ["full"] }
-tokio-tungstenite = { version = "0.24.0", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.24.0", features = [
+  "rustls-tls-native-roots",
+] }
 tracing = "0.1.40"
+tracing-subscriber = "0.3.19"

--- a/rust/client/src/ws/mod.rs
+++ b/rust/client/src/ws/mod.rs
@@ -64,6 +64,8 @@ impl BpxClient {
                                         tracing::error!("Failed to send message through the channel");
                                     }
                                 }
+                            } else if let Some(payload) = value.get("error") {
+                                tracing::error!("Websocket Error Response: {}", payload);
                             }
                         }
                     }

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/backpack-exchange/bpx-api-client"
 [dependencies]
 bpx-api-client = { path = "../client", features = ["ws"] }
 bpx-api-types = { path = "../types" }
+tracing-subscriber = { workspace = true }
 
 anyhow = { workspace = true }
 tokio = { workspace = true }

--- a/rust/examples/src/bin/rfq.rs
+++ b/rust/examples/src/bin/rfq.rs
@@ -6,6 +6,8 @@ use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     let base_url = env::var("BASE_URL").unwrap_or_else(|_| BACKPACK_API_BASE_URL.to_string());
     let ws_url = env::var("WS_URL").unwrap_or_else(|_| BACKPACK_WS_URL.to_string());
     let secret = env::var("SECRET").expect("Missing SECRET environment variable");

--- a/rust/types/src/rfq.rs
+++ b/rust/types/src/rfq.rs
@@ -48,7 +48,6 @@ pub struct RequestForQuoteStream {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "e", rename_all = "camelCase")] // Discriminates based on "e" field
 pub enum RequestForQuoteUpdate {
-    #[serde(rename = "rfqActive")]
     RfqActive {
         #[serde(rename = "E")]
         event_time: i64,
@@ -71,7 +70,6 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "rfqRefreshed")]
     RfqRefreshed {
         #[serde(rename = "E")]
         event_time: i64,
@@ -96,7 +94,6 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "rfqAccepted")]
     RfqAccepted {
         #[serde(rename = "E")]
         event_time: i64,
@@ -121,7 +118,6 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "rfqCancelled")]
     RfqCancelled {
         #[serde(rename = "E")]
         event_time: i64,
@@ -146,7 +142,6 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "quoteAccepted")]
     QuoteAccepted {
         #[serde(rename = "E")]
         event_time: i64,
@@ -165,7 +160,6 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "quoteCancelled")]
     QuoteCancelled {
         #[serde(rename = "E")]
         event_time: i64,
@@ -184,7 +178,6 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "rfqCandidate")]
     RfqCandidate {
         #[serde(rename = "E")]
         event_time: i64,
@@ -203,13 +196,12 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
         quote_quantity: Option<Decimal>,
         #[serde(rename = "p")]
-        price: Decimal, // This is the taker_price from the quote
+        price: Decimal,
         #[serde(rename = "X")]
         order_status: OrderStatus,
         #[serde(rename = "T")]
         timestamp: i64,
     },
-    #[serde(rename = "rfqFilled")]
     RfqFilled {
         #[serde(rename = "E")]
         event_time: i64,

--- a/rust/types/src/rfq.rs
+++ b/rust/types/src/rfq.rs
@@ -46,8 +46,9 @@ pub struct RequestForQuoteStream {
 
 /// RequestForQuote updates received from the websocket.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "e", rename_all = "camelCase")] // Discriminates based on "e" field
+#[serde(tag = "e")]
 pub enum RequestForQuoteUpdate {
+    #[serde(rename = "rfqActive")]
     RfqActive {
         #[serde(rename = "E")]
         event_time: i64,
@@ -57,8 +58,12 @@ pub enum RequestForQuoteUpdate {
         client_id: Option<u32>,
         #[serde(rename = "s")]
         symbol: String,
-        #[serde(rename = "q")]
-        quantity: Decimal,
+        #[serde(rename = "q", skip_serializing_if = "Option::is_none")]
+        quantity: Option<Decimal>,
+        #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
+        quote_quantity: Option<Decimal>,
+        #[serde(rename = "w")]
+        submission_time: i64,
         #[serde(rename = "W")]
         expiry_time: i64,
         #[serde(rename = "X")]
@@ -66,6 +71,82 @@ pub enum RequestForQuoteUpdate {
         #[serde(rename = "T")]
         timestamp: i64,
     },
+    #[serde(rename = "rfqRefreshed")]
+    RfqRefreshed {
+        #[serde(rename = "E")]
+        event_time: i64,
+        #[serde(rename = "R")]
+        rfq_id: u64,
+        #[serde(rename = "C", skip_serializing_if = "Option::is_none")]
+        client_id: Option<u32>,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "S")]
+        side: Side,
+        #[serde(rename = "q", skip_serializing_if = "Option::is_none")]
+        quantity: Option<Decimal>,
+        #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
+        quote_quantity: Option<Decimal>,
+        #[serde(rename = "w")]
+        submission_time: i64,
+        #[serde(rename = "W")]
+        expiry_time: i64,
+        #[serde(rename = "X")]
+        order_status: OrderStatus,
+        #[serde(rename = "T")]
+        timestamp: i64,
+    },
+    #[serde(rename = "rfqAccepted")]
+    RfqAccepted {
+        #[serde(rename = "E")]
+        event_time: i64,
+        #[serde(rename = "R")]
+        rfq_id: u64,
+        #[serde(rename = "C", skip_serializing_if = "Option::is_none")]
+        client_id: Option<u32>,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "S")]
+        side: Side,
+        #[serde(rename = "q", skip_serializing_if = "Option::is_none")]
+        quantity: Option<Decimal>,
+        #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
+        quote_quantity: Option<Decimal>,
+        #[serde(rename = "w")]
+        submission_time: i64,
+        #[serde(rename = "W")]
+        expiry_time: i64,
+        #[serde(rename = "X")]
+        order_status: OrderStatus,
+        #[serde(rename = "T")]
+        timestamp: i64,
+    },
+    #[serde(rename = "rfqCancelled")]
+    RfqCancelled {
+        #[serde(rename = "E")]
+        event_time: i64,
+        #[serde(rename = "R")]
+        rfq_id: u64,
+        #[serde(rename = "C", skip_serializing_if = "Option::is_none")]
+        client_id: Option<u32>,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "S")]
+        side: Side,
+        #[serde(rename = "q", skip_serializing_if = "Option::is_none")]
+        quantity: Option<Decimal>,
+        #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
+        quote_quantity: Option<Decimal>,
+        #[serde(rename = "w")]
+        submission_time: i64,
+        #[serde(rename = "W")]
+        expiry_time: i64,
+        #[serde(rename = "X")]
+        order_status: OrderStatus,
+        #[serde(rename = "T")]
+        timestamp: i64,
+    },
+    #[serde(rename = "quoteAccepted")]
     QuoteAccepted {
         #[serde(rename = "E")]
         event_time: i64,
@@ -73,38 +154,63 @@ pub enum RequestForQuoteUpdate {
         rfq_id: u64,
         #[serde(rename = "u")]
         quote_id: u64,
+        #[serde(rename = "C", skip_serializing_if = "Option::is_none")]
+        client_id: Option<u32>,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "p", skip_serializing_if = "Option::is_none")]
+        price: Option<Decimal>,
         #[serde(rename = "X")]
         order_status: OrderStatus,
         #[serde(rename = "T")]
         timestamp: i64,
     },
+    #[serde(rename = "quoteCancelled")]
     QuoteCancelled {
+        #[serde(rename = "E")]
+        event_time: i64,
         #[serde(rename = "R")]
         rfq_id: u64,
         #[serde(rename = "u")]
         quote_id: u64,
-        #[serde(rename = "X")]
-        status: OrderStatus,
-        #[serde(rename = "E")]
-        event_time: i64,
-    },
-    RfqFilled {
-        #[serde(rename = "E")]
-        event_time: i64,
-        #[serde(rename = "R")]
-        rfq_id: u64,
-        #[serde(rename = "Q")]
-        quote_id: u64,
-        #[serde(rename = "S")]
-        side: Side,
-        #[serde(rename = "p")]
-        price: Decimal,
+        #[serde(rename = "C", skip_serializing_if = "Option::is_none")]
+        client_id: Option<u32>,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "p", skip_serializing_if = "Option::is_none")]
+        price: Option<Decimal>,
         #[serde(rename = "X")]
         order_status: OrderStatus,
         #[serde(rename = "T")]
         timestamp: i64,
     },
+    #[serde(rename = "rfqCandidate")]
     RfqCandidate {
+        #[serde(rename = "E")]
+        event_time: i64,
+        #[serde(rename = "R")]
+        rfq_id: u64,
+        #[serde(rename = "u")]
+        quote_id: u64,
+        #[serde(rename = "C", skip_serializing_if = "Option::is_none")]
+        client_id: Option<u32>,
+        #[serde(rename = "s")]
+        symbol: String,
+        #[serde(rename = "S", skip_serializing_if = "Option::is_none")]
+        side: Option<Side>,
+        #[serde(rename = "q", skip_serializing_if = "Option::is_none")]
+        quantity: Option<Decimal>,
+        #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
+        quote_quantity: Option<Decimal>,
+        #[serde(rename = "p")]
+        price: Decimal, // This is the taker_price from the quote
+        #[serde(rename = "X")]
+        order_status: OrderStatus,
+        #[serde(rename = "T")]
+        timestamp: i64,
+    },
+    #[serde(rename = "rfqFilled")]
+    RfqFilled {
         #[serde(rename = "E")]
         event_time: i64,
         #[serde(rename = "R")]
@@ -121,8 +227,8 @@ pub enum RequestForQuoteUpdate {
         quantity: Option<Decimal>,
         #[serde(rename = "Q", skip_serializing_if = "Option::is_none")]
         quote_quantity: Option<Decimal>,
-        #[serde(rename = "p")]
-        price: Decimal,
+        #[serde(rename = "p", skip_serializing_if = "Option::is_none")]
+        price: Option<Decimal>,
         #[serde(rename = "X")]
         order_status: OrderStatus,
         #[serde(rename = "T")]

--- a/rust/types/src/rfq.rs
+++ b/rust/types/src/rfq.rs
@@ -46,7 +46,7 @@ pub struct RequestForQuoteStream {
 
 /// RequestForQuote updates received from the websocket.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "e")]
+#[serde(tag = "e", rename_all = "camelCase")] // Discriminates based on "e" field
 pub enum RequestForQuoteUpdate {
     #[serde(rename = "rfqActive")]
     RfqActive {


### PR DESCRIPTION
Add the remaining fields and types for RFQ updates.
When  receiving an error WS response for e.g. Invalid Signature, log it.