### PR TITLE
clippy: fixes for 'uninlined_format_args' rule

### DIFF
--- a/rust/client/src/routes/capital.rs
+++ b/rust/client/src/routes/capital.rs
@@ -32,7 +32,7 @@ impl BpxClient {
         let mut url = format!("{}{}", self.base_url, API_DEPOSITS);
         for (k, v) in [("limit", limit), ("offset", offset)] {
             if let Some(v) = v {
-                url.push_str(&format!("&{}={}", k, v));
+                url.push_str(&format!("&{k}={v}"));
             }
         }
         let res = self.get(url).await?;
@@ -51,7 +51,7 @@ impl BpxClient {
         let mut url = format!("{}{}", self.base_url, API_WITHDRAWALS);
         for (k, v) in [("limit", limit), ("offset", offset)] {
             if let Some(v) = v {
-                url.push_str(&format!("{}={}&", k, v));
+                url.push_str(&format!("{k}={v}&"));
             }
         }
         let res = self.get(url).await?;

--- a/rust/client/src/routes/markets.rs
+++ b/rust/client/src/routes/markets.rs
@@ -76,7 +76,7 @@ impl BpxClient {
         );
         for (k, v) in [("start_time", start_time), ("end_time", end_time)] {
             if let Some(v) = v {
-                url.push_str(&format!("&{}={}", k, v));
+                url.push_str(&format!("&{k}={v}"));
             }
         }
         let res = self.get(url).await?;

--- a/rust/client/src/routes/order.rs
+++ b/rust/client/src/routes/order.rs
@@ -13,7 +13,7 @@ impl BpxClient {
     pub async fn get_open_order(&self, symbol: &str, order_id: Option<&str>, client_id: Option<u32>) -> Result<Order> {
         let mut url = format!("{}{}?symbol={}", self.base_url, API_ORDER, symbol);
         if let Some(order_id) = order_id {
-            url.push_str(&format!("&orderId={}", order_id));
+            url.push_str(&format!("&orderId={order_id}"));
         } else {
             url.push_str(&format!(
                 "&clientId={}",

--- a/rust/client/src/routes/trades.rs
+++ b/rust/client/src/routes/trades.rs
@@ -11,7 +11,7 @@ impl BpxClient {
     pub async fn get_recent_trades(&self, symbol: &str, limit: Option<i16>) -> Result<Vec<Trade>> {
         let mut url = format!("{}{}?symbol={}", self.base_url, API_TRADES, symbol);
         if let Some(limit) = limit {
-            url.push_str(&format!("&limit={}", limit));
+            url.push_str(&format!("&limit={limit}"));
         }
         let res = self.get(url).await?;
         res.json().await.map_err(Into::into)
@@ -27,7 +27,7 @@ impl BpxClient {
         let mut url = format!("{}{}?symbol={}", self.base_url, API_TRADES_HISTORY, symbol);
         for (k, v) in [("limit", limit), ("offset", offset)] {
             if let Some(v) = v {
-                url.push_str(&format!("&{}={}", k, v));
+                url.push_str(&format!("&{k}={v}"));
             }
         }
         let res = self.get(url).await?;

--- a/rust/client/src/ws/mod.rs
+++ b/rust/client/src/ws/mod.rs
@@ -33,7 +33,7 @@ impl BpxClient {
     {
         let timestamp = now_millis();
         let window = DEFAULT_WINDOW;
-        let message = format!("instruction=subscribe&timestamp={}&window={}", timestamp, window);
+        let message = format!("instruction=subscribe&timestamp={timestamp}&window={window}");
 
         let verifying_key = STANDARD.encode(self.verifier.to_bytes());
         let signature = STANDARD.encode(self.signer.sign(message.as_bytes()).to_bytes());

--- a/rust/examples/src/bin/orders.rs
+++ b/rust/examples/src/bin/orders.rs
@@ -9,7 +9,7 @@ async fn main() {
     let client = BpxClient::init(base_url, &secret, None).expect("Failed to initialize Backpack API client");
 
     match client.get_open_orders(Some("SOL_USDC")).await {
-        Ok(orders) => println!("Open Orders: {:?}", orders),
-        Err(err) => tracing::error!("Error: {:?}", err),
+        Ok(orders) => println!("Open Orders: {orders:?}"),
+        Err(err) => tracing::error!("Error: {err:?}"),
     }
 }

--- a/rust/examples/src/bin/rfq.rs
+++ b/rust/examples/src/bin/rfq.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<RequestForQuoteUpdate>(100);
     tokio::spawn(async move {
         while let Some(rfq) = rx.recv().await {
-            println!("Received RFQ: {:?}", rfq);
+            println!("Received RFQ: {rfq:?}");
         }
     });
 


### PR DESCRIPTION
not sure if we want to solve it like this, feels like a mix of inlined and uninlined handling isn’t quite right 🤔

```rust
let mut url = format!("{}{}", self.base_url, API_DEPOSITS);
for (k, v) in [("limit", limit), ("offset", offset)] {
    if let Some(v) = v {
        url.push_str(&format!("&{k}={v}"));
    }
}
```
