### PR TITLE
add support for history api - Get order history

### DIFF
--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -41,6 +41,7 @@ use routes::{
     borrow_lend::API_BORROW_LEND_POSITIONS,
     capital::{API_CAPITAL, API_COLLATERAL, API_DEPOSITS, API_DEPOSIT_ADDRESS, API_WITHDRAWALS},
     futures::API_FUTURES_POSITION,
+    history::API_ORDER_HISTORY,
     order::{API_ORDER, API_ORDERS},
     rfq::{API_RFQ, API_RFQ_QUOTE},
     user::API_USER_2FA,
@@ -65,6 +66,9 @@ pub use bpx_api_types as types;
 
 /// Re-export of the custom `Error` type and `Result` alias for error handling.
 pub use error::{Error, Result};
+
+/// Re-export of the order history query struct for convenience.
+pub use types::history::OrderHistoryQuery;
 
 const API_USER_AGENT: &str = "bpx-rust-client";
 const API_KEY_HEADER: &str = "X-API-Key";
@@ -256,6 +260,7 @@ impl BpxClient {
             API_ORDER if method == Method::DELETE => "orderCancel",
             API_ORDERS if method == Method::GET => "orderQueryAll",
             API_ORDERS if method == Method::DELETE => "orderCancelAll",
+            API_ORDER_HISTORY if method == Method::GET => "orderHistoryQueryAll",
             API_RFQ if method == Method::POST => "rfqSubmit",
             API_RFQ_QUOTE if method == Method::POST => "quoteSubmit",
             API_FUTURES_POSITION if method == Method::GET => "positionQuery",

--- a/rust/client/src/routes/history.rs
+++ b/rust/client/src/routes/history.rs
@@ -1,0 +1,53 @@
+use bpx_api_types::history::OrderHistoryQuery;
+use bpx_api_types::order::Order;
+
+use crate::error::Result;
+use crate::BpxClient;
+
+#[doc(hidden)]
+pub const API_ORDER_HISTORY: &str = "/wapi/v1/history/orders";
+
+impl BpxClient {
+    /// Retrieves the order history for the user. This includes orders that have
+    /// been filled and are no longer on the book. It won't include orders
+    /// that are on the book. For open orders, use the `get_open_order` api.
+    pub async fn get_order_history(&self, query: Option<OrderHistoryQuery>) -> Result<Vec<Order>> {
+        let mut url = format!("{}{}", self.base_url, API_ORDER_HISTORY);
+        
+        if let Some(query) = query {
+            let mut params = vec![];
+            
+            if let Some(order_id) = &query.order_id {
+                params.push(format!("orderId={}", order_id));
+            }
+            if let Some(strategy_id) = &query.strategy_id {
+                params.push(format!("strategyId={}", strategy_id));
+            }
+            if let Some(symbol) = &query.symbol {
+                params.push(format!("symbol={}", symbol));
+            }
+            if let Some(limit) = query.limit {
+                params.push(format!("limit={}", limit));
+            }
+            if let Some(offset) = query.offset {
+                params.push(format!("offset={}", offset));
+            }
+            if let Some(market_types) = &query.market_type {
+                for market_type in market_types {
+                    params.push(format!("marketType={}", market_type));
+                }
+            }
+            if let Some(sort_direction) = &query.sort_direction {
+                params.push(format!("sortDirection={}", sort_direction));
+            }
+            
+            if !params.is_empty() {
+                url.push('?');
+                url.push_str(&params.join("&"));
+            }
+        }
+        
+        let res = self.get(url).await?;
+        res.json().await.map_err(Into::into)
+    }
+} 

--- a/rust/client/src/routes/mod.rs
+++ b/rust/client/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod borrow_lend;
 pub mod capital;
 pub mod futures;
+pub mod history;
 pub mod markets;
 pub mod order;
 pub mod rfq;

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -21,5 +21,9 @@ name = "orders"
 path = "src/bin/orders.rs"
 
 [[bin]]
+name = "history"
+path = "src/bin/order_history.rs"
+
+[[bin]]
 name = "rfq"
 path = "src/bin/rfq.rs"

--- a/rust/examples/src/bin/order_history.rs
+++ b/rust/examples/src/bin/order_history.rs
@@ -1,0 +1,30 @@
+use bpx_api_client::{BpxClient, OrderHistoryQuery, BACKPACK_API_BASE_URL};
+use bpx_api_types::SortDirection;
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    let base_url = env::var("BASE_URL").unwrap_or_else(|_| BACKPACK_API_BASE_URL.to_string());
+    let secret = env::var("SECRET").expect("Missing SECRET environment variable");
+
+    let client = BpxClient::init(base_url, &secret, None).expect("Failed to initialize Backpack API client");
+
+    println!("=== CALLING GET_OPEN_ORDERS ===");
+    match client.get_open_orders(Some("SOL_USDC")).await {
+        Ok(orders) => println!("Open Orders parsed successfully: {} orders, {:?}", orders.len(), orders),
+        Err(err) => eprintln!("Open Orders Error: {:?}", err),
+    }
+
+    println!("\n=== CALLING GET_ORDER_HISTORY ===");
+    let query = OrderHistoryQuery {
+        symbol: Some("SOL_USDC".to_string()),
+        limit: Some(5),
+        sort_direction: Some(SortDirection::Desc),
+        ..Default::default()
+    };
+
+    match client.get_order_history(Some(query)).await {
+        Ok(orders) => println!("Order History parsed successfully: {} orders, first order: {:?}", orders.len(), orders.first()),
+        Err(err) => eprintln!("Order History Error: {:?}", err),
+    }
+} 

--- a/rust/types/src/history.rs
+++ b/rust/types/src/history.rs
@@ -1,0 +1,43 @@
+use serde::Serialize;
+
+use crate::{MarketType, SortDirection};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderHistoryQuery {
+    /// Filter to the given order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_id: Option<String>,
+    /// Filter to the given strategy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy_id: Option<String>,
+    /// Filter to the given symbol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Maximum number to return. Default `100`, maximum `1000`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    /// Offset. Default `0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+    /// Market type filter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub market_type: Option<Vec<MarketType>>,
+    /// Sort direction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_direction: Option<SortDirection>,
+}
+
+impl Default for OrderHistoryQuery {
+    fn default() -> Self {
+        Self {
+            order_id: None,
+            strategy_id: None,
+            symbol: None,
+            limit: None,
+            offset: None,
+            market_type: None,
+            sort_direction: None,
+        }
+    }
+} 

--- a/rust/types/src/lib.rs
+++ b/rust/types/src/lib.rs
@@ -10,12 +10,33 @@ pub mod account;
 pub mod borrow_lend;
 pub mod capital;
 pub mod futures;
+pub mod history;
 pub mod margin;
 pub mod markets;
 pub mod order;
 pub mod rfq;
 pub mod trade;
 pub mod user;
+
+#[derive(Debug, Display, Clone, Copy, Serialize, Deserialize, EnumString, PartialEq, Eq, Hash, EnumIter)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum MarketType {
+    Spot,
+    Perp,
+    Iperp,
+    Dated,
+    Prediction,
+    Rfq,
+}
+
+#[derive(Debug, Display, Clone, Copy, Serialize, Deserialize, EnumString, PartialEq, Eq, Hash, EnumIter)]
+#[strum(serialize_all = "PascalCase")]
+#[serde(rename_all = "PascalCase")]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
 
 #[derive(Debug, Display, Clone, Copy, Serialize, Deserialize, Default, EnumString, PartialEq, Eq, Hash, EnumIter)]
 #[strum(serialize_all = "PascalCase")]


### PR DESCRIPTION
#### Change Summary 
- added routed layer for "Get order history" API 
- se/de change for existing `Order` struct to support `created_at` parsing of `i64` and date format. Since open_order and order_history are returning different formats.

Existing `Order` struct change is more risky, so we added unit tests to make it is backwards compatible. 

#### Tests
- Unit test for `Order` struct parsing 
- E2E test with real "Get order history" call 

