### PR TITLE
fixes the get_k_lines method to properly match the BPX API specification 

### DIFF
--- a/rust/client/src/routes/markets.rs
+++ b/rust/client/src/routes/markets.rs
@@ -67,14 +67,14 @@ impl BpxClient {
         &self,
         symbol: &str,
         kline_interval: &str,
-        start_time: Option<i64>,
+        start_time: i64,
         end_time: Option<i64>,
     ) -> Result<Vec<Kline>> {
         let mut url = format!(
-            "/{}{}?symbol={}&kline_interval={}",
-            self.base_url, API_KLINES, symbol, kline_interval
+            "{}{}?symbol={}&interval={}&startTime={}",
+            self.base_url, API_KLINES, symbol, kline_interval, start_time
         );
-        for (k, v) in [("start_time", start_time), ("end_time", end_time)] {
+        for (k, v) in [("endTime", end_time)] {
             if let Some(v) = v {
                 url.push_str(&format!("&{k}={v}"));
             }

--- a/rust/types/src/markets.rs
+++ b/rust/types/src/markets.rs
@@ -203,7 +203,7 @@ pub struct Kline {
     pub close: Option<Decimal>,
     pub end: Option<String>,
     pub volume: Decimal,
-    pub trades: u64,
+    pub trades: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Hi team,

this PR fixes the `get_k_lines` method to properly match the BPX API specification and resolves type compatibility issues with the `Kline` struct.
see. https://docs.backpack.exchange/#tag/Markets/operation/get_klines

### changes

- changed from `Option<i64>` to `i64` as the API requires a starting timestamp
- removed extra leading slash that was causing malformed URLs on `get_k_lines` endpoint
- correct parameter names: 
  - `kline_interval` → `interval` 
  - `start_time` → `startTime`
  - `end_time` → `endTime`
- optional parameter logic to only handle `endTime`
- changed from `u64` to `String` to match API response format