### PR TITLE
feat(client): return response body in deserialization errors

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -20,6 +20,20 @@ pub enum Error {
         message: Box<str>,
     },
 
+    /// Response body could not be deserialized into the expected type.
+    ///
+    /// Carries the full response body so callers can inspect what the API
+    /// actually returned. `Display` shows a truncated preview of the body.
+    #[error(
+        "Failed to deserialize API response: {source}; body: {}",
+        body_preview(body)
+    )]
+    Deserialize {
+        #[source]
+        source: serde_json::Error,
+        body: Box<str>,
+    },
+
     /// Invalid HTTP header value.
     #[error(transparent)]
     InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
@@ -60,5 +74,39 @@ pub enum Error {
 impl From<url::ParseError> for Error {
     fn from(e: url::ParseError) -> Self {
         Error::UrlParseError(e.to_string().into_boxed_str())
+    }
+}
+
+/// Maximum number of bytes of a response body included in error messages.
+const BODY_PREVIEW_LEN: usize = 2000;
+
+/// Truncates `body` to at most [`BODY_PREVIEW_LEN`] bytes on a char boundary.
+fn body_preview(body: &str) -> String {
+    if body.len() <= BODY_PREVIEW_LEN {
+        return body.to_string();
+    }
+    let mut end = BODY_PREVIEW_LEN;
+    while !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...[truncated, {} bytes total]", &body[..end], body.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_preview_does_not_split_multibyte_chars() {
+        // 'é' is 2 bytes; 1999 ASCII bytes + 'é' puts byte 2000 mid-character.
+        let body = format!("{}é{}", "a".repeat(BODY_PREVIEW_LEN - 1), "b".repeat(100));
+        let preview = body_preview(&body);
+        assert!(preview.starts_with(&"a".repeat(BODY_PREVIEW_LEN - 1)));
+        assert!(preview.contains("truncated"));
+    }
+
+    #[test]
+    fn body_preview_passes_short_bodies_through() {
+        assert_eq!(body_preview("{}"), "{}");
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -176,6 +176,32 @@ impl BpxClient {
         Ok(res)
     }
 
+    /// Deserializes the response body as JSON, logging the body at error level on failure.
+    ///
+    /// Unlike `Response::json()`, this method captures the response body and logs it
+    /// if deserialization fails, making it easier to debug API changes.
+    pub async fn json_with_context<T: serde::de::DeserializeOwned>(res: Response) -> Result<T> {
+        let body = res.text().await?;
+        serde_json::from_str(&body).map_err(|error| {
+            // Truncate very long responses for readability in logs
+            let body_preview = if body.len() > 2000 {
+                format!(
+                    "{}...[truncated, {} bytes total]",
+                    &body[..2000],
+                    body.len()
+                )
+            } else {
+                body
+            };
+            tracing::error!(
+                %error,
+                body_preview,
+                "Failed to deserialize API response"
+            );
+            error.into()
+        })
+    }
+
     /// Sends a GET request to the specified URL and signs it before execution.
     pub async fn get<U: IntoUrl>(&self, url: U) -> Result<Response> {
         let req = self.build_and_maybe_sign_request::<(), _>(url, Method::GET, None)?;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -177,29 +177,21 @@ impl BpxClient {
         Ok(res)
     }
 
-    /// Deserializes the response body as JSON, logging the body at error level on failure.
+    /// Deserializes the response body as JSON.
     ///
-    /// Unlike `Response::json()`, this method captures the response body and logs it
-    /// if deserialization fails, making it easier to debug API changes.
-    pub async fn json_with_context<T: serde::de::DeserializeOwned>(res: Response) -> Result<T> {
+    /// Unlike `Response::json()`, this reads the body as text first so that a
+    /// deserialization failure can carry the body in [`Error::Deserialize`],
+    /// making it easier to debug API changes.
+    pub(crate) async fn deserialize_json<T: serde::de::DeserializeOwned>(
+        res: Response,
+    ) -> Result<T> {
         let body = res.text().await?;
-        serde_json::from_str(&body).map_err(|error| {
-            // Truncate very long responses for readability in logs
-            let body_preview = if body.len() > 2000 {
-                format!(
-                    "{}...[truncated, {} bytes total]",
-                    &body[..2000],
-                    body.len()
-                )
-            } else {
-                body
-            };
-            tracing::error!(
-                %error,
-                body_preview,
-                "Failed to deserialize API response"
-            );
-            error.into()
+        serde_json::from_str(&body).map_err(|source| {
+            tracing::debug!(%source, body, "Failed to deserialize API response");
+            Error::Deserialize {
+                source,
+                body: body.into(),
+            }
         })
     }
 

--- a/client/src/routes/account.rs
+++ b/client/src/routes/account.rs
@@ -21,7 +21,7 @@ impl BpxClient {
     pub async fn get_account(&self) -> Result<AccountSettings> {
         let url = self.base_url.join(API_ACCOUNT)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the account's maximum borrow amount for a given symbol.
@@ -29,7 +29,7 @@ impl BpxClient {
         let mut url = self.base_url.join(API_ACCOUNT_MAX_BORROW)?;
         url.query_pairs_mut().append_pair("symbol", symbol);
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the account's maximum order amount for a given symbol.
@@ -39,7 +39,7 @@ impl BpxClient {
             .map_err(|e| Error::UrlParseError(e.to_string().into_boxed_str()))?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the account's maximum withdrawal amount for a given symbol.
@@ -61,7 +61,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Updates the account's settings.

--- a/client/src/routes/account.rs
+++ b/client/src/routes/account.rs
@@ -21,7 +21,7 @@ impl BpxClient {
     pub async fn get_account(&self) -> Result<AccountSettings> {
         let url = self.base_url.join(API_ACCOUNT)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the account's maximum borrow amount for a given symbol.
@@ -29,7 +29,7 @@ impl BpxClient {
         let mut url = self.base_url.join(API_ACCOUNT_MAX_BORROW)?;
         url.query_pairs_mut().append_pair("symbol", symbol);
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the account's maximum order amount for a given symbol.
@@ -39,7 +39,7 @@ impl BpxClient {
             .map_err(|e| Error::UrlParseError(e.to_string().into_boxed_str()))?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the account's maximum withdrawal amount for a given symbol.
@@ -61,7 +61,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Updates the account's settings.

--- a/client/src/routes/borrow_lend.rs
+++ b/client/src/routes/borrow_lend.rs
@@ -10,6 +10,6 @@ impl BpxClient {
     pub async fn get_borrow_lend_positions(&self) -> Result<Vec<BorrowLendPosition>> {
         let url = self.base_url.join(API_BORROW_LEND_POSITIONS)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/borrow_lend.rs
+++ b/client/src/routes/borrow_lend.rs
@@ -10,6 +10,6 @@ impl BpxClient {
     pub async fn get_borrow_lend_positions(&self) -> Result<Vec<BorrowLendPosition>> {
         let url = self.base_url.join(API_BORROW_LEND_POSITIONS)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/capital.rs
+++ b/client/src/routes/capital.rs
@@ -24,7 +24,7 @@ impl BpxClient {
     pub async fn get_balances(&self) -> Result<HashMap<String, Balance>> {
         let url = self.base_url.join(API_CAPITAL)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Retrieves a list of deposits with optional pagination.
@@ -44,7 +44,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the deposit address for a specified blockchain.
@@ -53,7 +53,7 @@ impl BpxClient {
         url.query_pairs_mut()
             .append_pair("blockchain", &blockchain.to_string());
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Retrieves a list of withdrawals with optional pagination.
@@ -73,7 +73,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Submits a withdrawal request for the specified payload.
@@ -83,13 +83,13 @@ impl BpxClient {
     ) -> Result<Withdrawal> {
         let endpoint = self.base_url.join(API_WITHDRAWALS)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the subaccount's collateral information.
     pub async fn get_collateral(&self) -> Result<Collateral> {
         let url = self.base_url.join(API_COLLATERAL)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/capital.rs
+++ b/client/src/routes/capital.rs
@@ -24,7 +24,7 @@ impl BpxClient {
     pub async fn get_balances(&self) -> Result<HashMap<String, Balance>> {
         let url = self.base_url.join(API_CAPITAL)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves a list of deposits with optional pagination.
@@ -44,7 +44,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the deposit address for a specified blockchain.
@@ -53,7 +53,7 @@ impl BpxClient {
         url.query_pairs_mut()
             .append_pair("blockchain", &blockchain.to_string());
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves a list of withdrawals with optional pagination.
@@ -73,7 +73,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Submits a withdrawal request for the specified payload.
@@ -83,13 +83,13 @@ impl BpxClient {
     ) -> Result<Withdrawal> {
         let endpoint = self.base_url.join(API_WITHDRAWALS)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the subaccount's collateral information.
     pub async fn get_collateral(&self) -> Result<Collateral> {
         let url = self.base_url.join(API_COLLATERAL)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/futures.rs
+++ b/client/src/routes/futures.rs
@@ -10,6 +10,6 @@ impl BpxClient {
     pub async fn get_open_future_positions(&self) -> Result<Vec<FuturePosition>> {
         let url = self.base_url.join(API_FUTURES_POSITION)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/futures.rs
+++ b/client/src/routes/futures.rs
@@ -10,6 +10,6 @@ impl BpxClient {
     pub async fn get_open_future_positions(&self) -> Result<Vec<FuturePosition>> {
         let url = self.base_url.join(API_FUTURES_POSITION)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/history.rs
+++ b/client/src/routes/history.rs
@@ -14,6 +14,6 @@ impl BpxClient {
         let mut url = self.base_url.join(API_FILLS_HISTORY)?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/history.rs
+++ b/client/src/routes/history.rs
@@ -14,6 +14,6 @@ impl BpxClient {
         let mut url = self.base_url.join(API_FILLS_HISTORY)?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/markets.rs
+++ b/client/src/routes/markets.rs
@@ -19,21 +19,21 @@ impl BpxClient {
     pub async fn get_assets(&self) -> Result<Vec<Asset>> {
         let url = self.base_url.join(API_ASSETS)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Retrieves a list of available markets.
     pub async fn get_markets(&self) -> Result<Vec<Market>> {
         let url = self.base_url.join(API_MARKETS)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Retrieves mark price, index price and the funding rate for the current interval for all symbols, or the symbol specified.
     pub async fn get_all_mark_prices(&self) -> Result<Vec<MarkPrice>> {
         let url = self.base_url.join(API_MARK_PRICES)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the ticker information for a given symbol.
@@ -41,14 +41,14 @@ impl BpxClient {
         let mut url = self.base_url.join(API_TICKER)?;
         url.query_pairs_mut().append_pair("symbol", symbol);
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches the ticker information for all symbols.
     pub async fn get_tickers(&self) -> Result<Vec<Ticker>> {
         let url = self.base_url.join(API_TICKERS)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Retrieves the order book depth for a given symbol.
@@ -63,7 +63,7 @@ impl BpxClient {
             url.query_pairs_mut().append_pair("limit", limit.as_ref());
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Funding interval rate history for futures.
@@ -71,7 +71,7 @@ impl BpxClient {
         let mut url = self.base_url.join(API_FUNDING)?;
         url.query_pairs_mut().append_pair("symbol", symbol);
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches historical K-line (candlestick) data for a given symbol and interval.
@@ -93,6 +93,6 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/markets.rs
+++ b/client/src/routes/markets.rs
@@ -21,21 +21,21 @@ impl BpxClient {
     pub async fn get_assets(&self) -> Result<Vec<Asset>> {
         let url = self.base_url.join(API_ASSETS)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves a list of available markets.
     pub async fn get_markets(&self) -> Result<Vec<Market>> {
         let url = self.base_url.join(API_MARKETS)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves mark price, index price and the funding rate for the current interval for all symbols, or the symbol specified.
     pub async fn get_all_mark_prices(&self) -> Result<Vec<MarkPrice>> {
         let url = self.base_url.join(API_MARK_PRICES)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the ticker information for a given symbol.
@@ -43,14 +43,14 @@ impl BpxClient {
         let mut url = self.base_url.join(API_TICKER)?;
         url.query_pairs_mut().append_pair("symbol", symbol);
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches the ticker information for all symbols.
     pub async fn get_tickers(&self) -> Result<Vec<Ticker>> {
         let url = self.base_url.join(API_TICKERS)?;
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves the order book depth for a given symbol.
@@ -65,7 +65,7 @@ impl BpxClient {
             url.query_pairs_mut().append_pair("limit", limit.as_ref());
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Funding interval rate history for futures.
@@ -73,14 +73,14 @@ impl BpxClient {
         let mut url = self.base_url.join(API_FUNDING)?;
         url.query_pairs_mut().append_pair("symbol", symbol);
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves tradable securities.
     pub async fn get_securities(&self) -> Result<Vec<Security>> {
         let url = self.base_url.join(API_SECURITIES)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::deserialize_json(res).await
     }
 
     /// Fetches historical K-line (candlestick) data for a given symbol and interval.
@@ -102,6 +102,6 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/order.rs
+++ b/client/src/routes/order.rs
@@ -36,14 +36,14 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Executes a new order with the given payload.
     pub async fn execute_order(&self, payload: ExecuteOrderPayload) -> Result<Order> {
         let endpoint = self.base_url.join(API_ORDER)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Cancels a specific order by symbol and either order ID or client ID.
@@ -61,7 +61,7 @@ impl BpxClient {
         };
 
         let res = self.delete(url, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Retrieves all open orders, optionally filtered by symbol.
@@ -71,13 +71,13 @@ impl BpxClient {
             url.query_pairs_mut().append_pair("symbol", s);
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Cancels all open orders matching the specified payload.
     pub async fn cancel_open_orders(&self, payload: CancelOpenOrdersPayload) -> Result<Vec<Order>> {
         let url = self.base_url.join(API_ORDERS)?;
         let res = self.delete(url, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/order.rs
+++ b/client/src/routes/order.rs
@@ -36,14 +36,14 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Executes a new order with the given payload.
     pub async fn execute_order(&self, payload: ExecuteOrderPayload) -> Result<Order> {
         let endpoint = self.base_url.join(API_ORDER)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Cancels a specific order by symbol and either order ID or client ID.
@@ -61,7 +61,7 @@ impl BpxClient {
         };
 
         let res = self.delete(url, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Retrieves all open orders, optionally filtered by symbol.
@@ -71,7 +71,7 @@ impl BpxClient {
             url.query_pairs_mut().append_pair("symbol", s);
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Executes a new order with the given payload.
@@ -81,13 +81,13 @@ impl BpxClient {
     ) -> Result<Vec<BatchOrderResponse>> {
         let endpoint = self.base_url.join(API_ORDERS)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::deserialize_json(res).await
     }
 
     /// Cancels all open orders matching the specified payload.
     pub async fn cancel_open_orders(&self, payload: CancelOpenOrdersPayload) -> Result<Vec<Order>> {
         let url = self.base_url.join(API_ORDERS)?;
         let res = self.delete(url, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/rfq.rs
+++ b/client/src/routes/rfq.rs
@@ -29,7 +29,7 @@ impl BpxClient {
     pub async fn submit_rfq(&self, payload: RequestForQuotePayload) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     pub async fn cancel_rfq(
@@ -38,7 +38,7 @@ impl BpxClient {
     ) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ_CANCEL)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     pub async fn refresh_rfq(
@@ -47,19 +47,19 @@ impl BpxClient {
     ) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ_REFRESH)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     pub async fn accept_quote(&self, payload: QuoteAcceptPayload) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ_ACCEPT)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     pub async fn submit_quote(&self, payload: QuotePayload) -> Result<Quote> {
         let endpoint = self.base_url.join(API_RFQ_QUOTE)?;
         let res = self.post(endpoint, payload).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     #[cfg(feature = "ws")]

--- a/client/src/routes/rfq.rs
+++ b/client/src/routes/rfq.rs
@@ -29,7 +29,7 @@ impl BpxClient {
     pub async fn submit_rfq(&self, payload: RequestForQuotePayload) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     pub async fn cancel_rfq(
@@ -38,7 +38,7 @@ impl BpxClient {
     ) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ_CANCEL)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     pub async fn refresh_rfq(
@@ -47,19 +47,19 @@ impl BpxClient {
     ) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ_REFRESH)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     pub async fn accept_quote(&self, payload: QuoteAcceptPayload) -> Result<RequestForQuote> {
         let endpoint = self.base_url.join(API_RFQ_ACCEPT)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     pub async fn submit_quote(&self, payload: QuotePayload) -> Result<Quote> {
         let endpoint = self.base_url.join(API_RFQ_QUOTE)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     #[cfg(feature = "ws")]

--- a/client/src/routes/trades.rs
+++ b/client/src/routes/trades.rs
@@ -18,7 +18,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 
     /// Fetches historical trades for a given symbol, with optional limit and offset.
@@ -40,6 +40,6 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/trades.rs
+++ b/client/src/routes/trades.rs
@@ -18,7 +18,7 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 
     /// Fetches historical trades for a given symbol, with optional limit and offset.
@@ -40,6 +40,6 @@ impl BpxClient {
             }
         }
         let res = self.get(url).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/user.rs
+++ b/client/src/routes/user.rs
@@ -16,8 +16,6 @@ impl BpxClient {
     ) -> Result<RequestTwoFactorResponse> {
         let endpoint = self.base_url.join(API_USER_2FA)?;
         let res = self.post(endpoint, payload).await?;
-
-        let data: RequestTwoFactorResponse = res.json().await?;
-        Ok(data)
+        Self::json_with_context(res).await
     }
 }

--- a/client/src/routes/user.rs
+++ b/client/src/routes/user.rs
@@ -16,6 +16,6 @@ impl BpxClient {
     ) -> Result<RequestTwoFactorResponse> {
         let endpoint = self.base_url.join(API_USER_2FA)?;
         let res = self.post(endpoint, payload).await?;
-        Self::json_with_context(res).await
+        Self::deserialize_json(res).await
     }
 }

--- a/client/src/routes/vault.rs
+++ b/client/src/routes/vault.rs
@@ -25,7 +25,7 @@ impl BpxClient {
     pub async fn get_vaults(&self) -> Result<Vec<Vault>> {
         let url = self.base_url.join(API_VAULTS)?;
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::deserialize_json(res).await
     }
 
     /// Mints vault tokens by depositing an asset into a vault.
@@ -59,7 +59,7 @@ impl BpxClient {
         let mut url = self.base_url.join(API_VAULTS_HISTORY)?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::deserialize_json(res).await
     }
 
     /// Fetches vault mint history (authenticated).
@@ -69,7 +69,7 @@ impl BpxClient {
         let mut url = self.base_url.join(API_VAULT_MINTS_HISTORY)?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::deserialize_json(res).await
     }
 
     /// Fetches vault redeem history (authenticated).
@@ -82,6 +82,6 @@ impl BpxClient {
         let mut url = self.base_url.join(API_VAULT_REDEEMS_HISTORY)?;
         url.set_query(Some(&query_string));
         let res = self.get(url).await?;
-        res.json().await.map_err(Into::into)
+        Self::deserialize_json(res).await
     }
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -59,6 +59,7 @@ pub enum Blockchain {
     Optimism,
     Aptos,
     Sei,
+    Stable,
     Tron,
     #[strum(serialize = "0G")]
     #[serde(rename = "0G")]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -58,7 +58,6 @@ pub enum Blockchain {
     Optimism,
     Aptos,
     Sei,
-    Stable,
     Tron,
     #[strum(serialize = "0G")]
     #[serde(rename = "0G")]


### PR DESCRIPTION
this adds a new pattern for handling errors when json bodies don't match the rust schema, so that the errors include more detail of what didn't deserialize. this helped me figure out what was wrong when the get_assets endpoint failed when monad was added