### PR TITLE
feat(types): expose market order book state and add unknown enum fallbacks

### DIFF
--- a/types/src/capital.rs
+++ b/types/src/capital.rs
@@ -44,6 +44,8 @@ pub enum DepositSource {
     Ethereum,
     Bitcoin,
     Nuvei,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Display, Clone, Copy, Serialize, Deserialize, EnumString, PartialEq, Eq, Hash)]
@@ -52,6 +54,8 @@ pub enum DepositSource {
 pub enum DepositStatus {
     Pending,
     Confirmed,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -106,6 +110,8 @@ pub enum WithdrawalStatus {
     Confirmed,
     Verifying,
     Void,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/types/src/markets.rs
+++ b/types/src/markets.rs
@@ -85,6 +85,10 @@ pub struct Market {
     pub market_type: String,
     /// See [`MarketFilters`].
     pub filters: MarketFilters,
+    /// Current state of the market's order book.
+    pub order_book_state: OrderBookState,
+    /// Whether the market is currently listed/visible on the exchange.
+    pub visible: bool,
 }
 
 impl Market {
@@ -101,6 +105,40 @@ impl Market {
     pub const fn quantity_decimal_places(&self) -> u32 {
         self.filters.quantity.step_size.scale()
     }
+}
+
+/// The state of a market's order book.
+///
+/// New states may be added by the exchange in the future; unrecognized values
+/// deserialize to [`OrderBookState::Unknown`].
+#[derive(
+    Debug,
+    strum::Display,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumString,
+    PartialEq,
+    Eq,
+    Hash,
+)]
+#[strum(serialize_all = "PascalCase")]
+#[serde(rename_all = "PascalCase")]
+pub enum OrderBookState {
+    /// Normal operation: accepting and matching orders.
+    Open,
+    /// Not accepting any orders.
+    Closed,
+    /// Only cancellation of existing orders; no execution.
+    CancelOnly,
+    /// Only accepting limit orders.
+    LimitOnly,
+    /// Only accepting orders that would not immediately match.
+    PostOnly,
+    /// Any state not recognized by this client version.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -517,6 +555,8 @@ mod test {
                 },
                 leverage: None,
             },
+            order_book_state: OrderBookState::Open,
+            visible: true,
         }
     }
 
@@ -609,5 +649,32 @@ mod test {
 
         let depth: OrderBookDepth = serde_json::from_str(data).unwrap();
         assert_eq!(depth.last_update_id, 94978271);
+    }
+
+    #[test]
+    fn test_market_order_book_state_and_visible_parse() {
+        let data = r#"
+{
+  "symbol": "WEN_USDC",
+  "baseSymbol": "WEN",
+  "quoteSymbol": "USDC",
+  "marketType": "SPOT",
+  "filters": {
+    "price": { "minPrice": "0.0001", "tickSize": "0.0001" },
+    "quantity": { "minQuantity": "0.01", "stepSize": "0.01" }
+  },
+  "orderBookState": "Closed",
+  "visible": false
+}
+        "#;
+
+        let market: Market = serde_json::from_str(data).unwrap();
+        assert_eq!(market.order_book_state, OrderBookState::Closed);
+        assert!(!market.visible);
+
+        // Unrecognized states fall back to `Unknown` rather than failing the parse.
+        let unknown = data.replace("\"Closed\"", "\"SomeFutureState\"");
+        let market: Market = serde_json::from_str(&unknown).unwrap();
+        assert_eq!(market.order_book_state, OrderBookState::Unknown);
     }
 }


### PR DESCRIPTION
## Summary

- `markets`: add `order_book_state: OrderBookState` and `visible: bool` to `Market`. Both are returned by the `/markets` REST response but were previously dropped by the client. Adds an `OrderBookState` enum (`Open`, `Closed`, `CancelOnly`, `LimitOnly`, `PostOnly`) following the existing typed-enum convention (PascalCase serde + strum) with a `#[serde(other)] Unknown` fallback so a future exchange state can't break `get_markets()` parsing.
- `capital`: add `#[serde(other)] Unknown` fallbacks to `DepositSource`, `DepositStatus`, and `WithdrawalStatus` so unrecognized values deserialize to `Unknown` instead of failing the whole response.

## Verification

- `cargo test -p bpx-api-types markets` — 7 passed (adds `test_market_order_book_state_and_visible_parse`, covering the `Closed`/`visible=false` round-trip and the `Unknown` fallback)
- `cargo clippy -p bpx-api-types` — clean
- `cargo build -p bpx-api-client` — builds

## Risk

- Additive and forward-compatible for deserialization. The only source-breaking change is that `Market` struct literals must now set `order_book_state` and `visible` (the in-crate test fixture is updated); typical consumers deserialize `Market` rather than construct it.
