### PR TITLE
fix(types): skip None fields in FillsHistoryParams query serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.5" }
 dotenv = "0.15"
 ed25519-dalek = "2"
 futures-util = { default-features = false, version = "0.3" }
+rand = "0.8"
 reqwest = { version = "0.13.2", default-features = false, features = ["json"] }
 rust_decimal = "1"
 rust_decimal_macros = "1"
@@ -39,3 +40,4 @@ tokio-tungstenite = { version = "0.29.0", features = [
 tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2"
+wiremock = "0.6.5"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,4 +37,11 @@ ws = ["futures-util", "tokio", "tokio-tungstenite"]
 integration-tests = []
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+base64ct = { workspace = true }
+ed25519-dalek = { workspace = true, features = ["rand_core"] }
+rand = { workspace = true }
+rust_decimal = { workspace = true }
+rust_decimal_macros = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wiremock = { workspace = true }

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -1,0 +1,9 @@
+use base64ct::{Base64, Encoding};
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+
+/// Returns a base64-encoded ed25519 seed for tests.
+pub fn test_secret() -> String {
+    let signing_key = SigningKey::generate(&mut OsRng);
+    Base64::encode_string(&signing_key.to_bytes())
+}

--- a/client/tests/get_historical_fills.rs
+++ b/client/tests/get_historical_fills.rs
@@ -1,0 +1,100 @@
+mod common;
+
+use bpx_api_client::{
+    BpxClient,
+    types::{fill::Fill, fill::FillsHistoryParams, history::SortDirection, order::Side},
+};
+use rust_decimal_macros::dec;
+use std::collections::BTreeMap;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+#[tokio::test]
+async fn get_historical_fills_omits_none_query_params() {
+    let mock_server = MockServer::start().await;
+
+    let mock_fills = vec![Fill {
+        trade_id: None,
+        client_id: None,
+        order_id: "1".to_string(),
+        symbol: "SOL_USDC".to_string(),
+        fee_symbol: "USDC".to_string(),
+        price: dec!(1),
+        quantity: dec!(100),
+        fee: dec!(0),
+        side: Side::Ask,
+        timestamp: "1970-01-01T00:00:01".to_string(),
+        is_maker: false,
+        system_order_type: None,
+    }];
+
+    Mock::given(method("GET"))
+        .and(path("/wapi/v1/history/fills"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            serde_json::to_string(&mock_fills).expect("mock fills should serialize"),
+            "application/json",
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let client = BpxClient::builder()
+        .base_url(mock_server.uri())
+        .secret(&common::test_secret())
+        .build()
+        .expect("client should build");
+
+    let params = FillsHistoryParams::default()
+        .with_from(1000)
+        .with_to(2000)
+        .with_limit(1000)
+        .with_offset(0)
+        .with_sort_direction(SortDirection::Asc);
+
+    let fills = client
+        .get_historical_fills(params)
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(fills, mock_fills);
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("wiremock should record requests");
+    assert_eq!(requests.len(), 1);
+
+    let request = &requests[0];
+    assert!(request.headers.contains_key("x-signature"));
+    assert!(request.headers.contains_key("x-timestamp"));
+    assert!(request.headers.contains_key("x-window"));
+    assert!(request.headers.contains_key("x-api-key"));
+
+    let query = request
+        .url
+        .query()
+        .expect("fills history request should include query parameters");
+
+    for segment in query.split('&') {
+        assert!(
+            segment.contains('='),
+            "bare query key emitted for unset option: {segment:?} in {query:?}"
+        );
+    }
+
+    let pairs: BTreeMap<_, _> = query
+        .split('&')
+        .map(|segment| segment.split_once('=').expect("bare query key"))
+        .collect();
+    assert_eq!(
+        pairs,
+        BTreeMap::from([
+            ("from", "1000"),
+            ("limit", "1000"),
+            ("offset", "0"),
+            ("sort_direction", "Asc"),
+            ("to", "2000"),
+        ])
+    );
+}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -23,3 +23,4 @@ strum = { workspace = true }
 [dev-dependencies]
 rust_decimal_macros = { workspace = true }
 serde_json = { workspace = true }
+serde_qs = { workspace = true }

--- a/types/src/fill.rs
+++ b/types/src/fill.rs
@@ -26,7 +26,7 @@ pub enum FillType {
     CollateralConversionAndSpotLiquidation,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Fill {
     pub trade_id: Option<i64>,
@@ -46,24 +46,34 @@ pub struct Fill {
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct FillsHistoryParams {
     /// Filter by symbol
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol: Option<String>,
     /// From timestamp in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<i64>,
     /// To timestamp in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<i64>,
     /// Filter by fill type
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_type: Option<FillType>,
     /// Filter by market type
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub market_type: Option<String>,
     /// Filter by order ID
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_id: Option<String>,
     /// Filter by strategy ID
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub strategy_id: Option<String>,
     /// Maximum number of results to return
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
     /// Offset for pagination - default to 0
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<u64>,
     /// Sort direction
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort_direction: Option<SortDirection>,
 }
 
@@ -116,5 +126,44 @@ impl FillsHistoryParams {
     pub fn with_sort_direction(mut self, sort_direction: SortDirection) -> Self {
         self.sort_direction = Some(sort_direction);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fills_history_params_omits_none_fields_in_query_string() {
+        let params = FillsHistoryParams::default()
+            .with_from(1000)
+            .with_to(2000)
+            .with_limit(1000)
+            .with_offset(0)
+            .with_sort_direction(SortDirection::Asc);
+
+        let query = serde_qs::to_string(&params).unwrap();
+
+        for segment in query.split('&') {
+            assert!(
+                segment.contains('='),
+                "bare query key emitted for unset option: {segment:?} in {query:?}"
+            );
+        }
+
+        let pairs: Vec<_> = query
+            .split('&')
+            .map(|segment| segment.split_once('=').unwrap())
+            .collect();
+        assert_eq!(
+            pairs,
+            [
+                ("from", "1000"),
+                ("to", "2000"),
+                ("limit", "1000"),
+                ("offset", "0"),
+                ("sort_direction", "Asc"),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `skip_serializing_if = "Option::is_none"` to optional fields on `FillsHistoryParams`
- Fixes invalid signature errors on `get_historical_fills` after the serde_qs 1.1.x bump, which serializes unset `Option`s as bare keys