### PR TITLE
feat(types): add rwaMarketType to Market

### DIFF
--- a/types/src/markets.rs
+++ b/types/src/markets.rs
@@ -83,6 +83,11 @@ pub struct Market {
     /// The type of the market. Can be `SPOT`, `PERP`, `IPERP`, `DATED`, `PREDICTION`, `RFQ` or `MONAD`.
     /// New market types may also be added in the future.
     pub market_type: String,
+    /// The real-world-asset type backing the market, when the market is a
+    /// tokenized RWA (e.g. `STOCK` for tokenized equities such as
+    /// `SPCX.US_USDC`). `None` for regular crypto markets.
+    #[serde(default)]
+    pub rwa_market_type: Option<RwaMarketType>,
     /// See [`MarketFilters`].
     pub filters: MarketFilters,
     /// Current state of the market's order book.
@@ -137,6 +142,38 @@ pub enum OrderBookState {
     /// Only accepting orders that would not immediately match.
     PostOnly,
     /// Any state not recognized by this client version.
+    #[serde(other)]
+    Unknown,
+}
+
+/// The type of real-world asset backing a tokenized RWA market.
+///
+/// New types may be added by the exchange in the future; unrecognized values
+/// deserialize to [`RwaMarketType::Unknown`].
+#[derive(
+    Debug,
+    strum::Display,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumString,
+    PartialEq,
+    Eq,
+    Hash,
+)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RwaMarketType {
+    /// A tokenized equity.
+    Stock,
+    /// A tokenized index.
+    Index,
+    /// A tokenized commodity.
+    Commodity,
+    /// A tokenized foreign-exchange pair.
+    Fx,
+    /// Any type not recognized by this client version.
     #[serde(other)]
     Unknown,
 }
@@ -534,6 +571,7 @@ mod test {
             base_symbol: "TEST".to_string(),
             quote_symbol: "MARKET".to_string(),
             market_type: "SPOT".to_string(),
+            rwa_market_type: None,
             filters: super::MarketFilters {
                 price: PriceFilter {
                     min_price: dec!(0.0001),
@@ -676,5 +714,53 @@ mod test {
         let unknown = data.replace("\"Closed\"", "\"SomeFutureState\"");
         let market: Market = serde_json::from_str(&unknown).unwrap();
         assert_eq!(market.order_book_state, OrderBookState::Unknown);
+    }
+
+    #[test]
+    fn test_market_rwa_market_type_parse() {
+        let data = r#"
+{
+  "symbol": "SPCX.US_USDC",
+  "baseSymbol": "SPCX.US",
+  "quoteSymbol": "USDC",
+  "marketType": "SPOT",
+  "rwaMarketType": "STOCK",
+  "filters": {
+    "price": { "minPrice": "0.01", "tickSize": "0.01" },
+    "quantity": { "minQuantity": "0.01", "stepSize": "0.01" }
+  },
+  "orderBookState": "PostOnly",
+  "visible": false
+}
+        "#;
+
+        let market: Market = serde_json::from_str(data).unwrap();
+        assert_eq!(market.rwa_market_type, Some(RwaMarketType::Stock));
+
+        // The exchange's full RWA set: STOCK, INDEX, COMMODITY, FX.
+        for (wire, expected) in [
+            ("INDEX", RwaMarketType::Index),
+            ("COMMODITY", RwaMarketType::Commodity),
+            ("FX", RwaMarketType::Fx),
+        ] {
+            let payload = data.replace("STOCK", wire);
+            let market: Market = serde_json::from_str(&payload).unwrap();
+            assert_eq!(market.rwa_market_type, Some(expected));
+        }
+
+        // Explicit null parses to `None`, as the API sends for crypto markets.
+        let null = data.replace("\"STOCK\"", "null");
+        let market: Market = serde_json::from_str(&null).unwrap();
+        assert_eq!(market.rwa_market_type, None);
+
+        // An absent key parses to `None` for responses predating the field.
+        let absent = data.replace("\"rwaMarketType\": \"STOCK\",", "");
+        let market: Market = serde_json::from_str(&absent).unwrap();
+        assert_eq!(market.rwa_market_type, None);
+
+        // Unrecognized types fall back to `Unknown` rather than failing the parse.
+        let unknown = data.replace("\"STOCK\"", "\"SOME_FUTURE_RWA\"");
+        let market: Market = serde_json::from_str(&unknown).unwrap();
+        assert_eq!(market.rwa_market_type, Some(RwaMarketType::Unknown));
     }
 }


### PR DESCRIPTION
## Summary

- Backpack now lists tokenized equities (e.g. `SPCX.US_USDC`, `MU.US_USDC`) as regular SPOT markets carrying `rwaMarketType: "STOCK"` in `GET /api/v1/markets`; the client silently dropped the field, so consumers could not distinguish RWA markets from crypto.
- Add `Market.rwa_market_type: Option<RwaMarketType>` with `#[serde(default)]` — absent key (responses predating the field) and explicit `null` (crypto markets) both deserialize to `None`.
- New `RwaMarketType` enum covering the exchange's full set (`STOCK`, `INDEX`, `COMMODITY`, `FX`, matching the backend's `rwa_market_type` postgres enum and public API surface) plus a `#[serde(other)] Unknown` fallback so future values can't fail a parse, mirroring the `OrderBookState` pattern.


## Risk

- Additive, deserialization-only: `deny_unknown_fields` is not used, so existing consumers are unaffected until they opt into the new field.
