### PR TITLE
feat(types): align Market with API fields

### DIFF
--- a/types/src/markets.rs
+++ b/types/src/markets.rs
@@ -1,7 +1,7 @@
 use rust_decimal::Decimal;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::Blockchain;
+use crate::{Blockchain, margin::MarginFunction};
 
 /// An asset is most of the time a crypto coin that can have multiple representations
 /// across different blockchains. For example, USDT.
@@ -90,10 +90,26 @@ pub struct Market {
     pub rwa_market_type: Option<RwaMarketType>,
     /// See [`MarketFilters`].
     pub filters: MarketFilters,
+    /// IMF function.
+    pub imf_function: Option<MarginFunction>,
+    /// MMF function.
+    pub mmf_function: Option<MarginFunction>,
+    /// Funding interval for perpetuals in milliseconds.
+    pub funding_interval: Option<u64>,
+    /// Funding rate upper bound for perpetual markets, in basis points (e.g. `10` = 10 bps).
+    pub funding_rate_upper_bound: Option<Decimal>,
+    /// Funding rate lower bound for perpetual markets, in basis points (e.g. `-10` = -10 bps).
+    pub funding_rate_lower_bound: Option<Decimal>,
+    /// Maximum open interest limit for the market, when applicable.
+    pub open_interest_limit: Option<Decimal>,
     /// Current state of the market's order book.
     pub order_book_state: OrderBookState,
+    /// Market created at time.
+    pub created_at: chrono::NaiveDateTime,
     /// Whether the market is currently listed/visible on the exchange.
     pub visible: bool,
+    /// Position limit weight coefficient used when clearing trades.
+    pub position_limit_weight: Option<Decimal>,
 }
 
 impl Market {
@@ -211,12 +227,21 @@ pub struct PriceFilter {
     /// Price band for futures markets. Restricts the premium moving too far
     /// from the mean premium.
     pub mean_premium_band: Option<PriceBandPremium>,
+    /// RWA price band restricting how far the price may move from the latest
+    /// external oracle price.
+    pub discovery_bound_band: Option<PriceBandDiscoveryBound>,
     /// Maximum allowed multiplier move from last active price without
     /// incurring an entry fee when borrowing for spot margin.
     pub borrow_entry_fee_max_multiplier: Option<Decimal>,
     /// Minimum allowed multiplier move from last active price without
     /// incurring an entry fee when borrowing for spot margin.
     pub borrow_entry_fee_min_multiplier: Option<Decimal>,
+    /// Maximum allowed multiplier for mark/index price updates relative to the
+    /// previous mark/index price.
+    pub max_price_update_multiplier: Option<Decimal>,
+    /// Minimum allowed multiplier for mark/index price updates relative to the
+    /// previous mark/index price.
+    pub min_price_update_multiplier: Option<Decimal>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -244,6 +269,15 @@ pub struct PriceBandPremium {
     /// orders will be prevented from being placed if the premium exceeds 10%.
     /// User to calculate `min_premium_pct` and `max_premium_pct`.
     pub tolerance_pct: Decimal,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceBandDiscoveryBound {
+    /// Maximum allowed multiplier move from the external oracle price.
+    pub max_multiplier: Decimal,
+    /// Minimum allowed multiplier move from the external oracle price.
+    pub min_multiplier: Decimal,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -583,8 +617,11 @@ mod test {
                     min_impact_multiplier: Some(dec!(0.95)),
                     mean_mark_price_band: None,
                     mean_premium_band: None,
+                    discovery_bound_band: None,
                     borrow_entry_fee_max_multiplier: None,
                     borrow_entry_fee_min_multiplier: None,
+                    max_price_update_multiplier: None,
+                    min_price_update_multiplier: None,
                 },
                 quantity: QuantityFilter {
                     min_quantity: dec!(0.01),
@@ -593,8 +630,20 @@ mod test {
                 },
                 leverage: None,
             },
+            imf_function: None,
+            mmf_function: None,
+            funding_interval: None,
+            funding_rate_upper_bound: None,
+            funding_rate_lower_bound: None,
+            open_interest_limit: None,
             order_book_state: OrderBookState::Open,
+            created_at: chrono::NaiveDateTime::parse_from_str(
+                "2025-01-21T06:34:54.691858",
+                "%Y-%m-%dT%H:%M:%S%.f",
+            )
+            .unwrap(),
             visible: true,
+            position_limit_weight: None,
         }
     }
 
@@ -702,6 +751,7 @@ mod test {
     "quantity": { "minQuantity": "0.01", "stepSize": "0.01" }
   },
   "orderBookState": "Closed",
+  "createdAt": "2025-01-21T06:34:54.691858",
   "visible": false
 }
         "#;
@@ -730,6 +780,7 @@ mod test {
     "quantity": { "minQuantity": "0.01", "stepSize": "0.01" }
   },
   "orderBookState": "PostOnly",
+  "createdAt": "2025-01-21T06:34:54.691858",
   "visible": false
 }
         "#;
@@ -762,5 +813,80 @@ mod test {
         let unknown = data.replace("\"STOCK\"", "\"SOME_FUTURE_RWA\"");
         let market: Market = serde_json::from_str(&unknown).unwrap();
         assert_eq!(market.rwa_market_type, Some(RwaMarketType::Unknown));
+    }
+
+    #[test]
+    fn test_market_perp_fields_parse() {
+        let data = r#"
+{
+  "baseSymbol": "SOL",
+  "createdAt": "2025-01-21T06:34:54.691858",
+  "filters": {
+    "price": {
+      "borrowEntryFeeMaxMultiplier": null,
+      "borrowEntryFeeMinMultiplier": null,
+      "maxImpactMultiplier": "1.01",
+      "maxMultiplier": "2",
+      "maxPrice": "1000",
+      "meanMarkPriceBand": {
+        "maxMultiplier": "1.1",
+        "minMultiplier": "0.9"
+      },
+      "meanPremiumBand": {
+        "tolerancePct": "0.05"
+      },
+      "minImpactMultiplier": "0.99",
+      "minMultiplier": "0.25",
+      "minPrice": "0.01",
+      "tickSize": "0.01"
+    },
+    "quantity": {
+      "maxQuantity": null,
+      "minQuantity": "0.01",
+      "stepSize": "0.01"
+    }
+  },
+  "fundingInterval": 3600000,
+  "fundingRateLowerBound": "-100",
+  "fundingRateUpperBound": "100",
+  "imfFunction": {
+    "base": "0.02",
+    "factor": "0.00006",
+    "type": "sqrt"
+  },
+  "marketType": "PERP",
+  "mmfFunction": {
+    "base": "0.0135",
+    "factor": "0.000036",
+    "type": "sqrt"
+  },
+  "openInterestLimit": "4000000",
+  "orderBookState": "Open",
+  "positionLimitWeight": "1",
+  "quoteSymbol": "USDC",
+  "symbol": "SOL_USDC_PERP",
+  "visible": true
+}
+        "#;
+
+        let market: Market = serde_json::from_str(data).unwrap();
+        assert_eq!(market.symbol, "SOL_USDC_PERP");
+        assert_eq!(market.funding_interval, Some(3600000));
+        assert_eq!(market.funding_rate_lower_bound, Some(dec!(-100)));
+        assert_eq!(market.funding_rate_upper_bound, Some(dec!(100)));
+        assert_eq!(market.open_interest_limit, Some(dec!(4000000)));
+        assert_eq!(market.position_limit_weight, Some(dec!(1)));
+        assert_eq!(market.imf_function.as_ref().unwrap().function_type, "sqrt");
+        assert_eq!(market.imf_function.as_ref().unwrap().base, dec!(0.02));
+        assert_eq!(
+            market
+                .filters
+                .price
+                .mean_premium_band
+                .as_ref()
+                .unwrap()
+                .tolerance_pct,
+            dec!(0.05)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add missing `Market` fields from the API: IMF/MMF functions, funding bounds, open interest limit, `createdAt`, and position limit weight
- Add missing `PriceFilter` fields: `discoveryBoundBand` and mark/index price update multipliers
- Add deserialization tests for PERP market payloads

## Test plan
- [x] `cargo test -p bpx-api-types markets::test`
- [x] Verified live `/api/v1/markets` JSON deserializes into `Market`