### PR TITLE
fix(client): re-enable reqwest TLS for HTTPS requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ dotenv = "0.15"
 ed25519-dalek = "3"
 futures-util = { default-features = false, version = "0.3" }
 rand = "0.10"
-reqwest = { version = "0.13.2", default-features = false, features = ["json"] }
+reqwest = { version = "0.13.2", default-features = false, features = [
+    "json",
+    "rustls",
+] }
 rust_decimal = "1"
 rust_decimal_macros = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Re-add `rustls` to the workspace reqwest dependency, which was dropped during the 0.13 upgrade (this was a mistake!)
- Fixes standalone HTTPS usage (`invalid URL, scheme is not http`) when no other crate in the graph enables TLS via feature unification

## Test plan
- [x] `cargo test -p bpx-api-client --features integration-tests test_get_markets`