### PR TITLE
chore(deps): bump ed25519-dalek to 3 and rand to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ base64ct = { version = "1", features = ["alloc"] }
 chrono = { default-features = false, version = "0.4", features = ["serde"] }
 clap = { version = "4.5" }
 dotenv = "0.15"
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 futures-util = { default-features = false, version = "0.3" }
-rand = "0.8"
+rand = "0.10"
 reqwest = { version = "0.13.2", default-features = false, features = ["json"] }
 rust_decimal = "1"
 rust_decimal_macros = "1"

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -1,9 +1,9 @@
 use base64ct::{Base64, Encoding};
 use ed25519_dalek::SigningKey;
-use rand::rngs::OsRng;
+use rand::rng;
 
 /// Returns a base64-encoded ed25519 seed for tests.
 pub fn test_secret() -> String {
-    let signing_key = SigningKey::generate(&mut OsRng);
+    let signing_key = SigningKey::generate(&mut rng());
     Base64::encode_string(&signing_key.to_bytes())
 }


### PR DESCRIPTION
## Summary
- Bump `ed25519-dalek` from 2 to 3
- Bump `rand` from 0.8 to 0.10
- Update test key generation to use `rand::rng()` after `OsRng` was removed in rand 0.10

## Test plan
- [x] `cargo check --all-targets --all-features`
- [x] `cargo test -p bpx-api-client --test get_historical_fills`
- [x] `cargo test -p bpx-api-types`